### PR TITLE
Refactored binding configuration, added native API support

### DIFF
--- a/gojaRuntime/gojaRuntime.go
+++ b/gojaRuntime/gojaRuntime.go
@@ -13,15 +13,20 @@ import (
 )
 
 type (
-	gojaRunnerV1 struct {
-		Cache *gojaCache
+	nativeModules struct {
+		registered map[string]*NativeModule
+	}
+
+	GojaRunnerV1 struct {
+		cache         *gojaCache
+		nativeModules nativeModules
 	}
 
 	actionResult struct {
-		ConsoleLog   []interface{}          `json:"console_log"`
-		ConsoleError []interface{}          `json:"console_error"`
-		Context      map[string]interface{} `json:"context"`
-		ExitResult   interface{}            `json:"exit_result"`
+		ConsoleLog   []interface{} `json:"console_log"`
+		ConsoleError []interface{} `json:"console_error"`
+		Context      jsContext     `json:"context"`
+		ExitResult   interface{}   `json:"exit_result"`
 	}
 	introspectedExport struct {
 		value interface{}
@@ -30,7 +35,19 @@ type (
 	introspectionResult struct {
 		exports map[string]introspectedExport
 	}
+
+	JsContext interface {
+		SetValue(key string, value interface{})
+	}
+	jsContext struct {
+		data map[string]interface{}
+	}
 )
+
+// SetValue implements JsContext.
+func (j jsContext) SetValue(key string, value interface{}) {
+	j.data[key] = value
+}
 
 // HasExport implements runtime_registry.IntrospectedExport.
 func (i introspectedExport) HasExport() bool {
@@ -73,7 +90,7 @@ func (a *actionResult) GetConsoleLog() []interface{} {
 
 // GetContext implements runtime_registry.Result.
 func (a *actionResult) GetContext() map[string]interface{} {
-	return a.Context
+	return a.Context.data
 }
 
 func (a *actionResult) GetExitResult() interface{} {
@@ -82,46 +99,120 @@ func (a *actionResult) GetExitResult() interface{} {
 
 var registry = new(require.Registry)
 
-var availableModules = map[string]func(e *gojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, result *actionResult, binding runtimesRegistry.ModuleBinding){
-	"console": func(runner *gojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, result *actionResult, binding runtimesRegistry.ModuleBinding) {
+var builtInModules = map[string]func(e *GojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, result *actionResult, binding runtimesRegistry.ModuleBinding){
+	"console": func(runner *GojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, result *actionResult, binding runtimesRegistry.ModuleBinding) {
 		vm.Set("console", vm.NewObject())
 		consoleMountingPoint := vm.Get("console").(*goja.Object)
 		runner.consoleEmulation(vm, consoleMountingPoint, result, binding)
 	},
-	"url": func(e *gojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, _ *actionResult, _ runtimesRegistry.ModuleBinding) {
+	"url": func(e *GojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, _ *actionResult, _ runtimesRegistry.ModuleBinding) {
 		vm.Set("url", require.Require(vm, "url"))
 	},
-	"module": func(e *gojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, _ *actionResult, _ runtimesRegistry.ModuleBinding) {
+	"module": func(e *GojaRunnerV1, vm *goja.Runtime, mountingPoint *goja.Object, _ *actionResult, _ runtimesRegistry.ModuleBinding) {
 		vm.Set("module", vm.NewObject())
 	},
 }
 
-var kindeAPIs = map[string]func(runtimesRegistry.ModuleBinding, ...interface{}) (interface{}, error){}
-
-func RegisterKindeAPI(apiName string, api func(runtimesRegistry.ModuleBinding, ...interface{}) (interface{}, error)) {
-	kindeAPIs[apiName] = api
-}
-
 func init() {
 	runtimesRegistry.RegisterRuntime("goja", newGojaRunner)
-
 	registry.RegisterNativeModule("url", urlModule.Require)
-
 }
 
 func newGojaRunner() runtimesRegistry.Runner {
-	runner := gojaRunnerV1{
-		Cache: &gojaCache{
+	runner := GojaRunnerV1{
+		cache: &gojaCache{
 			cache: map[string]*goja.Program{},
+		},
+		nativeModules: nativeModules{
+			registered: map[string]*NativeModule{},
 		},
 	}
 	return &runner
 }
 
+func (nm *NativeModule) setupModuleForVM(vm *goja.Runtime, actionResult *actionResult, parent *goja.Object, requestedName string, binding runtimesRegistry.ModuleBinding) {
+	for _, name := range strings.Split(requestedName, ".")[:1] {
+		if function, ok := nm.functions[name]; ok {
+			wrappedFunc := func(binding runtimesRegistry.ModuleBinding, jsContext jsContext) func(args ...interface{}) (interface{}, error) {
+				return func(args ...interface{}) (interface{}, error) {
+					return function(binding, jsContext, args...)
+				}
+			}
+			parent.Set(name, vm.ToValue(wrappedFunc(binding, actionResult.Context)))
+		}
+
+		if name == "" {
+			for fname, function := range nm.functions {
+
+				wrappedFunc := func(binding runtimesRegistry.ModuleBinding, jsContext jsContext) func(args ...interface{}) (interface{}, error) {
+					return func(args ...interface{}) (interface{}, error) {
+						return function(binding, jsContext, args...)
+					}
+				}
+
+				parent.Set(fname, vm.ToValue(wrappedFunc(binding, actionResult.Context)))
+			}
+			return
+		}
+
+		if module, ok := nm.modules[name]; ok {
+			registeredModule := vm.NewObject()
+			parent.Set(name, registeredModule)
+			module.setupModuleForVM(vm, actionResult, registeredModule, strings.Join(strings.Split(requestedName, ".")[1:], "."), binding)
+		}
+	}
+}
+
+func (nm *nativeModules) setupModuleForVM(vm *goja.Runtime, actionResult *actionResult, requestedName string, binding runtimesRegistry.ModuleBinding) {
+
+	for _, name := range strings.Split(requestedName, ".")[:1] {
+		if module, ok := nm.registered[name]; ok {
+			registeredModule := vm.Get(name)
+			if registeredModule == nil {
+				registeredModule = vm.NewObject()
+				vm.Set(name, registeredModule)
+			}
+			module.setupModuleForVM(vm, actionResult, registeredModule.(*goja.Object), strings.Join(strings.Split(requestedName, ".")[1:], "."), binding)
+		}
+	}
+
+}
+
+type NativeModule struct {
+	functions map[string]func(binding runtimesRegistry.ModuleBinding, jsContext JsContext, args ...interface{}) (interface{}, error)
+	modules   map[string]*NativeModule
+	name      string
+}
+
+func (runner GojaRunnerV1) RegisterNativeAPI(name string) *NativeModule {
+	result := &NativeModule{
+		functions: map[string]func(binding runtimesRegistry.ModuleBinding, jsContext JsContext, args ...interface{}) (interface{}, error){},
+		modules:   map[string]*NativeModule{},
+		name:      name,
+	}
+	runner.nativeModules.registered[name] = result
+	return result
+}
+
+func (module *NativeModule) RegisterNativeFunction(name string, fn func(binding runtimesRegistry.ModuleBinding, jsContext JsContext, args ...interface{}) (interface{}, error)) {
+
+	module.functions[name] = fn
+}
+
+func (module *NativeModule) RegisterNativeAPI(name string) *NativeModule {
+	result := &NativeModule{
+		functions: map[string]func(binding runtimesRegistry.ModuleBinding, jsContext JsContext, args ...interface{}) (interface{}, error){},
+		modules:   map[string]*NativeModule{},
+		name:      name,
+	}
+	module.modules[name] = result
+	return result
+}
+
 // Introspect implements runtime_registry.Runner.
-func (e *gojaRunnerV1) Introspect(ctx context.Context, workflow runtimesRegistry.WorkflowDescriptor, options runtimesRegistry.IntrospectionOptions) (runtimesRegistry.IntrospectionResult, error) {
+func (e *GojaRunnerV1) Introspect(ctx context.Context, workflow runtimesRegistry.WorkflowDescriptor, options runtimesRegistry.IntrospectionOptions) (runtimesRegistry.IntrospectionResult, error) {
 	vm := goja.New()
-	_, returnErr := setupVM(ctx, vm, e, workflow)
+	_, returnErr := e.setupVM(ctx, vm, workflow)
 
 	if returnErr != nil {
 		return nil, returnErr
@@ -146,10 +237,10 @@ func (e *gojaRunnerV1) Introspect(ctx context.Context, workflow runtimesRegistry
 	return introspectionResult, nil
 }
 
-func (e *gojaRunnerV1) Execute(ctx context.Context, workflow runtimesRegistry.WorkflowDescriptor, startOptions runtimesRegistry.StartOptions) (runtimesRegistry.ExecutionResult, error) {
+func (e *GojaRunnerV1) Execute(ctx context.Context, workflow runtimesRegistry.WorkflowDescriptor, startOptions runtimesRegistry.StartOptions) (runtimesRegistry.ExecutionResult, error) {
 
 	vm := goja.New()
-	executionResult, returnErr := setupVM(ctx, vm, e, workflow)
+	executionResult, returnErr := e.setupVM(ctx, vm, workflow)
 
 	if returnErr != nil {
 		return executionResult, returnErr
@@ -209,7 +300,7 @@ func (e *gojaRunnerV1) Execute(ctx context.Context, workflow runtimesRegistry.Wo
 	return executionResult, nil
 }
 
-func setupVM(ctx context.Context, vm *goja.Runtime, runner *gojaRunnerV1, workflow runtimesRegistry.WorkflowDescriptor) (*actionResult, error) {
+func (runner *GojaRunnerV1) setupVM(ctx context.Context, vm *goja.Runtime, workflow runtimesRegistry.WorkflowDescriptor) (*actionResult, error) {
 	registry.Enable(vm)
 
 	runner.maxExecutionTimeout(ctx, vm, workflow.Limits.MaxExecutionDuration)
@@ -218,25 +309,23 @@ func setupVM(ctx context.Context, vm *goja.Runtime, runner *gojaRunnerV1, workfl
 	executionResult := &actionResult{
 		ConsoleLog:   []interface{}{},
 		ConsoleError: []interface{}{},
-		Context:      map[string]interface{}{},
+		Context: jsContext{
+			data: map[string]interface{}{},
+		},
 	}
 
-	for name, binding := range workflow.Bindings.GlobalModules {
-		if module, ok := availableModules[name]; ok {
+	for name, binding := range workflow.RequestedBindings.Global {
+		if module, ok := builtInModules[name]; ok {
 			module(runner, vm, vm.NewObject(), executionResult, binding)
 		}
 	}
 
-	vm.Set("kinde", vm.NewObject())
-	for name, binding := range workflow.Bindings.KindeAPIs {
-		kindeMountPoint := vm.Get("kinde").(*goja.Object)
-		if apiFunc, ok := kindeAPIs[name]; ok {
-			kindeMountPoint.Set(name, runner.callRegisteredAPI(binding, apiFunc))
-		}
+	for requestedName, requestedBinding := range workflow.RequestedBindings.Native {
+		runner.nativeModules.setupModuleForVM(vm, executionResult, requestedName, requestedBinding)
 	}
 
 	workflowHash := workflow.GetHash()
-	program, err := runner.Cache.cacheProgram(workflowHash, func() (*goja.Program, error) {
+	program, err := runner.cache.cacheProgram(workflowHash, func() (*goja.Program, error) {
 		ast, err := goja.Parse("main", string(workflow.ProcessedSource.Source))
 
 		if err != nil {
@@ -264,7 +353,7 @@ func setupVM(ctx context.Context, vm *goja.Runtime, runner *gojaRunnerV1, workfl
 	return executionResult, nil
 }
 
-func (*gojaRunnerV1) maxExecutionTimeout(ctx context.Context, vm *goja.Runtime, maxExecutionDuration time.Duration) {
+func (*GojaRunnerV1) maxExecutionTimeout(ctx context.Context, vm *goja.Runtime, maxExecutionDuration time.Duration) {
 	go func() {
 		timer := time.NewTimer(maxExecutionDuration)
 		select {
@@ -279,7 +368,7 @@ func (*gojaRunnerV1) maxExecutionTimeout(ctx context.Context, vm *goja.Runtime, 
 	}()
 }
 
-func (*gojaRunnerV1) consoleEmulation(_ *goja.Runtime, mountingPoint *goja.Object, result *actionResult, _ runtimesRegistry.ModuleBinding) {
+func (*GojaRunnerV1) consoleEmulation(_ *goja.Runtime, mountingPoint *goja.Object, result *actionResult, _ runtimesRegistry.ModuleBinding) {
 
 	infoFunc := func(arguments ...interface{}) (interface{}, error) {
 		result.ConsoleLog = append(result.ConsoleLog, arguments)
@@ -296,13 +385,4 @@ func (*gojaRunnerV1) consoleEmulation(_ *goja.Runtime, mountingPoint *goja.Objec
 	mountingPoint.Set("debug", infoFunc)
 	mountingPoint.Set("warn", errorFunc)
 	mountingPoint.Set("error", errorFunc)
-}
-
-func (*gojaRunnerV1) callRegisteredAPI(binding runtimesRegistry.ModuleBinding, registeredFunc func(runtimesRegistry.ModuleBinding, ...interface{}) (interface{}, error)) func(...interface{}) (interface{}, error) {
-
-	wrapped := func(args ...interface{}) (interface{}, error) {
-		result, err := registeredFunc(binding, args...)
-		return result, err
-	}
-	return wrapped
 }

--- a/gojaRuntime/gojaRuntime.go
+++ b/gojaRuntime/gojaRuntime.go
@@ -89,8 +89,26 @@ func (a *actionResult) GetConsoleLog() []interface{} {
 }
 
 // GetContext implements runtime_registry.Result.
-func (a *actionResult) GetContext() map[string]interface{} {
-	return a.Context.data
+func (a *actionResult) GetContext() runtimesRegistry.RuntimeContext {
+	return a.Context
+}
+
+// GetValue implements runtimesRegistry.RuntimeContext.
+func (j jsContext) GetValues() map[string]interface{} {
+	return j.data
+}
+
+// GetValueAsMap implements runtime_registry.RuntimeContext.
+func (j jsContext) GetValueAsMap(key string) (map[string]interface{}, error) {
+	if value, ok := j.data[key]; ok {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			return v, nil
+		default:
+			return nil, fmt.Errorf("value is not a map")
+		}
+	}
+	return nil, fmt.Errorf("key not found")
 }
 
 func (a *actionResult) GetExitResult() interface{} {

--- a/projectBundler/projectBundler.go
+++ b/projectBundler/projectBundler.go
@@ -25,12 +25,9 @@ type (
 		EntryPoints           []string              `json:"entry_points"`
 		Bundle                bundler.BundlerResult `json:"bundle"`
 	}
-	KindeWorkflows struct {
-		Workflows []KindeWorkflow `json:"workflows"`
-	}
 
 	KindeEnvironment struct {
-		Workflows KindeWorkflows `json:"workflows"`
+		Workflows []KindeWorkflow `json:"workflows"`
 	}
 
 	KindeProject struct {
@@ -51,7 +48,7 @@ type (
 	}
 )
 
-func (kw *KindeWorkflows) discover(absLocation string) {
+func (kw *KindeEnvironment) discover(absLocation string) {
 	//environment/workflows
 	workflowsPath := filepath.Join(absLocation, "environment", "workflows")
 	//check if the folder exists
@@ -91,7 +88,7 @@ func (p *projectBundler) Discover() (*KindeProject, error) {
 		return nil, err
 	}
 
-	result.Environment.Workflows.discover(filepath.Join(result.Configuration.AbsLocation, result.Configuration.RootDir))
+	result.Environment.discover(filepath.Join(result.Configuration.AbsLocation, result.Configuration.RootDir))
 
 	return result, nil
 }

--- a/projectBundler/projectBundler_test.go
+++ b/projectBundler/projectBundler_test.go
@@ -23,8 +23,8 @@ func Test_ProjectBunler(t *testing.T) {
 	}
 	assert.Equal("2024-12-09", kindeProject.Configuration.Version)
 	assert.Equal("kindeSrc", kindeProject.Configuration.RootDir)
-	assert.Equal(2, len(kindeProject.Environment.Workflows.Workflows))
-	assert.Empty(kindeProject.Environment.Workflows.Workflows[0].Bundle.Errors)
-	assert.Empty(kindeProject.Environment.Workflows.Workflows[1].Bundle.Errors)
+	assert.Equal(2, len(kindeProject.Environment.Workflows))
+	assert.Empty(kindeProject.Environment.Workflows[0].Bundle.Errors)
+	assert.Empty(kindeProject.Environment.Workflows[1].Bundle.Errors)
 
 }

--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -21,7 +21,7 @@ type (
 		Arguments  []interface{}
 	}
 
-	CodeDescriptor struct {
+	SourceDescriptor struct {
 		Source     []byte            `json:"source"`
 		SourceType SourceContentType `json:"source_type"`
 		BuildHash  string            `json:"build_hash"`
@@ -45,9 +45,9 @@ type (
 	}
 
 	WorkflowDescriptor struct {
-		ProcessedSource CodeDescriptor `json:"processed_source"`
-		Bindings        Bindings       `json:"bindings"`
-		Limits          RuntimeLimits  `json:"runtime_limits"`
+		ProcessedSource SourceDescriptor `json:"processed_source"`
+		Bindings        Bindings         `json:"bindings"`
+		Limits          RuntimeLimits    `json:"runtime_limits"`
 	}
 
 	ExecutionResult interface {

--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -27,23 +28,23 @@ type (
 		BuildHash  string            `json:"build_hash"`
 	}
 
-	ModuleBinding struct {
+	BindingSettings struct {
 		Settings map[string]interface{} `json:"settings"`
 	}
 
-	Bindings struct {
-		Global map[string]ModuleBinding `json:"global"`
-		Native map[string]ModuleBinding `json:"native"`
-	}
+	// Bindings struct {
+	// 	Global map[string]ModuleBinding `json:"global"`
+	// 	Native map[string]ModuleBinding `json:"native"`
+	// }
 
 	RuntimeLimits struct {
 		MaxExecutionDuration time.Duration `json:"max_execution_duration"`
 	}
 
 	WorkflowDescriptor struct {
-		ProcessedSource   SourceDescriptor `json:"processed_source"`
-		RequestedBindings Bindings         `json:"bindings"`
-		Limits            RuntimeLimits    `json:"runtime_limits"`
+		ProcessedSource   SourceDescriptor           `json:"processed_source"`
+		RequestedBindings map[string]BindingSettings `json:"bindings"`
+		Limits            RuntimeLimits              `json:"runtime_limits"`
 	}
 
 	RuntimeContext interface {
@@ -62,7 +63,7 @@ type (
 		HasExport() bool
 		Value() interface{}
 		ValueAsMap() map[string]interface{}
-		BindingsFrom(exportName string) Bindings
+		BindingsFrom(exportName string) map[string]BindingSettings
 	}
 
 	IntrospectionResult interface {
@@ -78,6 +79,13 @@ type (
 		Introspect(ctx context.Context, workflow WorkflowDescriptor, options IntrospectionOptions) (IntrospectionResult, error)
 	}
 )
+
+func (settings *BindingSettings) UnmarshalJSON(data []byte) error {
+	jsonMap := map[string]interface{}{}
+	err := json.Unmarshal(data, &jsonMap)
+	settings.Settings = jsonMap
+	return err
+}
 
 var runtimes map[string]func() Runner = map[string]func() Runner{}
 

--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -49,11 +49,16 @@ type (
 		Limits            RuntimeLimits    `json:"runtime_limits"`
 	}
 
+	RuntimeContext interface {
+		GetValues() map[string]interface{}
+		GetValueAsMap(key string) (map[string]interface{}, error)
+	}
+
 	ExecutionResult interface {
 		GetExitResult() interface{}
 		GetConsoleLog() []interface{}
 		GetConsoleError() []interface{}
-		GetContext() map[string]interface{}
+		GetContext() RuntimeContext
 	}
 
 	IntrospectedExport interface {

--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -27,16 +27,13 @@ type (
 		BuildHash  string            `json:"build_hash"`
 	}
 
-	ModuleBindingConfiguration struct {
-		Settings map[string]interface{} `json:"configuration"`
-	}
 	ModuleBinding struct {
-		Configuration ModuleBindingConfiguration `json:"configuration"`
+		Settings map[string]interface{} `json:"settings"`
 	}
 
 	Bindings struct {
-		Global map[string]ModuleBinding `json:"global_modules"`
-		Native map[string]ModuleBinding `json:"native_modules"`
+		Global map[string]ModuleBinding `json:"global"`
+		Native map[string]ModuleBinding `json:"native"`
 	}
 
 	RuntimeLimits struct {
@@ -65,6 +62,7 @@ type (
 		HasExport() bool
 		Value() interface{}
 		ValueAsMap() map[string]interface{}
+		BindingsFrom(exportName string) Bindings
 	}
 
 	IntrospectionResult interface {

--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -32,12 +32,11 @@ type (
 	}
 	ModuleBinding struct {
 		Configuration ModuleBindingConfiguration `json:"configuration"`
-		ContextKey    string                     `json:"context_key"`
 	}
 
 	Bindings struct {
-		GlobalModules map[string]ModuleBinding `json:"global_modules"`
-		KindeAPIs     map[string]ModuleBinding `json:"kinde_apis"`
+		Global map[string]ModuleBinding `json:"global_modules"`
+		Native map[string]ModuleBinding `json:"native_modules"`
 	}
 
 	RuntimeLimits struct {
@@ -45,9 +44,9 @@ type (
 	}
 
 	WorkflowDescriptor struct {
-		ProcessedSource SourceDescriptor `json:"processed_source"`
-		Bindings        Bindings         `json:"bindings"`
-		Limits          RuntimeLimits    `json:"runtime_limits"`
+		ProcessedSource   SourceDescriptor `json:"processed_source"`
+		RequestedBindings Bindings         `json:"bindings"`
+		Limits            RuntimeLimits    `json:"runtime_limits"`
 	}
 
 	ExecutionResult interface {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -34,7 +34,7 @@ func Test_GojaRuntime(t *testing.T) {
 		return nil, nil
 	})
 
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 2; i++ {
 
 		result, err := runtime.Execute(context.Background(), registry.WorkflowDescriptor{
 			Limits: registry.RuntimeLimits{
@@ -68,5 +68,9 @@ func Test_GojaRuntime(t *testing.T) {
 		assert := assert.New(t)
 		assert.Nil(err)
 		assert.Equal("fetch response", fmt.Sprintf("%v", result.GetExitResult()))
+
+		idTokenMap, err := result.GetContext().GetValueAsMap("idToken")
+		assert.Nil(err)
+		assert.Equal("bbb", idTokenMap["aaa"])
 	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	goja_runtime "github.com/kinde-oss/workflows-runtime/gojaRuntime"
-	project_bundler "github.com/kinde-oss/workflows-runtime/projectBundler"
+	gojaRuntime "github.com/kinde-oss/workflows-runtime/gojaRuntime"
+	projectBundler "github.com/kinde-oss/workflows-runtime/projectBundler"
 	registry "github.com/kinde-oss/workflows-runtime/registry"
 )
 
@@ -60,7 +60,7 @@ func Test_GojaPrecompiledRuntime(t *testing.T) {
 func Test_ProjectBunlerE2E(t *testing.T) {
 	somePathInsideProject, _ := filepath.Abs("./testData/kindeSrc/environment/workflows") //starting in a middle of nowhere, so we need to go up to the root of the project
 
-	projectBundler := project_bundler.NewProjectBundler(project_bundler.DiscoveryOptions{
+	projectBundler := projectBundler.NewProjectBundler(projectBundler.DiscoveryOptions{
 		StartFolder: somePathInsideProject,
 	})
 
@@ -83,7 +83,7 @@ func Test_ProjectBunlerE2E(t *testing.T) {
 
 }
 
-func testExecution(workflow project_bundler.KindeWorkflow, assert *assert.Assertions) func(t *testing.T) {
+func testExecution(workflow projectBundler.KindeWorkflow, assert *assert.Assertions) func(t *testing.T) {
 	return func(t *testing.T) {
 		runner := getGojaRunner()
 		result, err := runner.Execute(context.Background(), registry.WorkflowDescriptor{
@@ -117,12 +117,12 @@ func testExecution(workflow project_bundler.KindeWorkflow, assert *assert.Assert
 func getGojaRunner() registry.Runner {
 	runtime, _ := GetRuntime("goja")
 
-	kindeAPI := runtime.(*goja_runtime.GojaRunnerV1).RegisterNativeAPI("kinde")
-	kindeAPI.RegisterNativeFunction("fetch", func(binding registry.ModuleBinding, jsContext goja_runtime.JsContext, args ...interface{}) (interface{}, error) {
+	kindeAPI := runtime.(*gojaRuntime.GojaRunnerV1).RegisterNativeAPI("kinde")
+	kindeAPI.RegisterNativeFunction("fetch", func(binding registry.ModuleBinding, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
 		return "fetch response", nil
 	})
 
-	kindeAPI.RegisterNativeAPI("idToken").RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext goja_runtime.JsContext, args ...interface{}) (interface{}, error) {
+	kindeAPI.RegisterNativeAPI("idToken").RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
 		}
@@ -134,7 +134,7 @@ func getGojaRunner() registry.Runner {
 		return nil, nil
 	})
 
-	kindeAPI.RegisterNativeAPI("accessToken").RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext goja_runtime.JsContext, args ...interface{}) (interface{}, error) {
+	kindeAPI.RegisterNativeAPI("accessToken").RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
 		}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -8,47 +8,65 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	gojaRuntime "github.com/kinde-oss/workflows-runtime/gojaRuntime"
+	goja_runtime "github.com/kinde-oss/workflows-runtime/gojaRuntime"
 	registry "github.com/kinde-oss/workflows-runtime/registry"
 )
 
 func Test_GojaRuntime(t *testing.T) {
 	runtime, _ := GetRuntime("goja")
 
-	gojaRuntime.RegisterKindeAPI("fetch", func(binding registry.ModuleBinding, args ...interface{}) (interface{}, error) {
+	kindeAPI := runtime.(*goja_runtime.GojaRunnerV1).RegisterNativeAPI("kinde")
+	kindeAPI.RegisterNativeFunction("fetch", func(binding registry.ModuleBinding, jsContext goja_runtime.JsContext, args ...interface{}) (interface{}, error) {
 		return "fetch response", nil
 	})
 
-	result, err := runtime.Execute(context.Background(), registry.WorkflowDescriptor{
-		Limits: registry.RuntimeLimits{
-			MaxExecutionDuration: 30 * time.Second,
-		},
-		Bindings: registry.Bindings{
-			GlobalModules: map[string]registry.ModuleBinding{
-				"console": {},
-				"url":     {},
-				"module":  {},
-				"kinde":   {},
+	idTokenAPI := kindeAPI.RegisterNativeAPI("idToken")
+	idTokenAPI.RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext goja_runtime.JsContext, args ...interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
+		}
+		name, ok1 := args[0].(string)
+		value, ok2 := args[1].(string)
+		if !ok1 || !ok2 {
+			return nil, fmt.Errorf("arguments must be strings")
+		}
+		jsContext.SetValue("idToken", map[string]interface{}{name: value})
+		return nil, nil
+	})
+
+	for i := 0; i < 1; i++ {
+
+		result, err := runtime.Execute(context.Background(), registry.WorkflowDescriptor{
+			Limits: registry.RuntimeLimits{
+				MaxExecutionDuration: 30 * time.Second,
 			},
-			KindeAPIs: map[string]registry.ModuleBinding{
-				"fetch": {},
-			},
-		},
-		ProcessedSource: registry.SourceDescriptor{
-			Source: []byte(`
+			ProcessedSource: registry.SourceDescriptor{
+				Source: []byte(`
 				var r=Object.defineProperty;var a=Object.getOwnPropertyDescriptor;var s=Object.getOwnPropertyNames;var g=Object.prototype.hasOwnProperty;var f=(t,e)=>{for(var n in e)r(t,n,{get:e[n],enumerable:!0})},i=(t,e,n,l)=>{if(e&&typeof e=="object"||typeof e=="function")for(let o of s(e))!g.call(t,o)&&o!==n&&r(t,o,{get:()=>e[o],enumerable:!(l=a(e,o))||l.enumerable});return t};var u=t=>i(r({},"__esModule",{value:!0}),t);var h={};
 				f(h,{default:()=>c,workflowSettings:()=>w});module.exports=u(h);const w={resetClaims:!0};
 				var c={async handle(t){
-					return console.log("logging from workflow",{balh:"blah"}), console.error("error"), kinde.fetch("hello.com")}
+					return console.log("logging from workflow",{balh:"blah"}), console.error("error"), kinde.idToken.setCustomClaim('aaa', 'bbb'), kinde.fetch("hello.com")}
 				};//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsibWFpbiJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiXG5cbiAgICAgICAgICAgICAgICAgICAgZXhwb3J0IGNvbnN0IHdvcmtmbG93U2V0dGluZ3MgPSB7XG4gICAgICAgICAgICAgICAgICAgICAgICByZXNldENsYWltczogdHJ1ZVxuICAgICAgICAgICAgICAgICAgICB9O1xuXG5cdFx0XHRcdFx0ZXhwb3J0IGRlZmF1bHQge1xuICAgICAgICAgICAgICAgICAgICAgICAgYXN5bmMgaGFuZGxlKGV2ZW50OiBhbnkpIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb25zb2xlLmxvZygnbG9nZ2luZyBmcm9tIHdvcmtmbG93Jywge1wiYmFsaFwiOiBcImJsYWhcIn0pO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJldHVybiAndGVzdGluZyByZXR1cm4nO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICAgICAgIl0sCiAgIm1hcHBpbmdzIjogIjRaQUFBLElBQUFBLEVBQUEsR0FBQUMsRUFBQUQsRUFBQSxhQUFBRSxFQUFBLHFCQUFBQyxJQUFBLGVBQUFDLEVBQUFKLEdBRTJCLE1BQU1HLEVBQW1CLENBQzVCLFlBQWEsRUFDakIsRUFFZixJQUFPRCxFQUFRLENBQ0ksTUFBTSxPQUFPRyxFQUFZLENBQ3JCLGVBQVEsSUFBSSx3QkFBeUIsQ0FBQyxLQUFRLE1BQU0sQ0FBQyxFQUM5QyxnQkFDWCxDQUVKIiwKICAibmFtZXMiOiBbIm1haW5fZXhwb3J0cyIsICJfX2V4cG9ydCIsICJtYWluX2RlZmF1bHQiLCAid29ya2Zsb3dTZXR0aW5ncyIsICJfX3RvQ29tbW9uSlMiLCAiZXZlbnQiXQp9Cg=="}
 			`),
-			SourceType: registry.Source_ContentType_Text,
-		},
-	}, registry.StartOptions{
-		EntryPoint: "handle",
-	})
+				SourceType: registry.Source_ContentType_Text,
+			},
+			RequestedBindings: registry.Bindings{
+				Global: map[string]registry.ModuleBinding{
+					"console": {},
+					"url":     {},
+					"module":  {},
+				},
+				Native: map[string]registry.ModuleBinding{
+					"kinde.fetch":   {},
+					"kinde.idToken": {},
+				},
+			},
+		}, registry.StartOptions{
+			EntryPoint: "handle",
+		})
 
-	assert := assert.New(t)
-	assert.Nil(err)
-	assert.Equal("fetch response", fmt.Sprintf("%v", result.GetExitResult()))
+		assert := assert.New(t)
+		assert.Nil(err)
+		assert.Equal("fetch response", fmt.Sprintf("%v", result.GetExitResult()))
+	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -33,15 +33,11 @@ func Test_GojaPrecompiledRuntime(t *testing.T) {
 			`),
 				SourceType: registry.Source_ContentType_Text,
 			},
-			RequestedBindings: registry.Bindings{
-				Global: map[string]registry.ModuleBinding{
-					"console": {},
-					"url":     {},
-				},
-				Native: map[string]registry.ModuleBinding{
-					"kinde.fetch":   {},
-					"kinde.idToken": {},
-				},
+			RequestedBindings: map[string]registry.BindingSettings{
+				"console":       {},
+				"url":           {},
+				"kinde.fetch":   {},
+				"kinde.idToken": {},
 			},
 		}, registry.StartOptions{
 			EntryPoint: "handle",
@@ -118,11 +114,11 @@ func getGojaRunner() registry.Runner {
 	runtime, _ := GetRuntime("goja")
 
 	kindeAPI := runtime.(*gojaRuntime.GojaRunnerV1).RegisterNativeAPI("kinde")
-	kindeAPI.RegisterNativeFunction("fetch", func(binding registry.ModuleBinding, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
+	kindeAPI.RegisterNativeFunction("fetch", func(binding registry.BindingSettings, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
 		return "fetch response", nil
 	})
 
-	kindeAPI.RegisterNativeAPI("idToken").RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
+	kindeAPI.RegisterNativeAPI("idToken").RegisterNativeFunction("setCustomClaim", func(binding registry.BindingSettings, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
 		}
@@ -134,7 +130,7 @@ func getGojaRunner() registry.Runner {
 		return nil, nil
 	})
 
-	kindeAPI.RegisterNativeAPI("accessToken").RegisterNativeFunction("setCustomClaim", func(binding registry.ModuleBinding, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
+	kindeAPI.RegisterNativeAPI("accessToken").RegisterNativeFunction("setCustomClaim", func(binding registry.BindingSettings, jsContext gojaRuntime.JsContext, args ...interface{}) (interface{}, error) {
 		if len(args) != 2 {
 			return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
 		}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -34,7 +34,7 @@ func Test_GojaRuntime(t *testing.T) {
 				"fetch": {},
 			},
 		},
-		ProcessedSource: registry.CodeDescriptor{
+		ProcessedSource: registry.SourceDescriptor{
 			Source: []byte(`
 				var r=Object.defineProperty;var a=Object.getOwnPropertyDescriptor;var s=Object.getOwnPropertyNames;var g=Object.prototype.hasOwnProperty;var f=(t,e)=>{for(var n in e)r(t,n,{get:e[n],enumerable:!0})},i=(t,e,n,l)=>{if(e&&typeof e=="object"||typeof e=="function")for(let o of s(e))!g.call(t,o)&&o!==n&&r(t,o,{get:()=>e[o],enumerable:!(l=a(e,o))||l.enumerable});return t};var u=t=>i(r({},"__esModule",{value:!0}),t);var h={};
 				f(h,{default:()=>c,workflowSettings:()=>w});module.exports=u(h);const w={resetClaims:!0};

--- a/testData/kindeSrc/environment/workflows/evTest/tokensWorkflow.ts
+++ b/testData/kindeSrc/environment/workflows/evTest/tokensWorkflow.ts
@@ -3,26 +3,17 @@ import {hello} from "./hello"
 export const workflowSettings = {
     id: 'tokenGen',
     trigger: 'onTokenGeneration',
-    resetClaims: true,
     bindings:{
-        "global": {
-            "console": {},
+        "console": {},
+        "kinde.fetch": {},
+        "kinde.idToken": {
+            resetClaims: true
         },
-        "native": {
-            "kinde.fetch": {},
-            "kinde.idToken": {},
-            "kinde.accessToken": {}
+        "kinde.accessToken": {
+            resetClaims: true
         }
     }
 };
-
-// bindings: ["console", "kinde.fetch", "kinde.idToken", "kinde.accessToken"],
-// settings: {
-//     "console": {},
-//     "kinde.idToken": {
-//         "resetClaims": true
-//     },
-// }
 
 export default async function handle (event: any) {
         kinde.idToken.setCustomClaim('random', 'test');

--- a/testData/kindeSrc/environment/workflows/evTest/tokensWorkflow.ts
+++ b/testData/kindeSrc/environment/workflows/evTest/tokensWorkflow.ts
@@ -4,10 +4,25 @@ export const workflowSettings = {
     id: 'tokenGen',
     trigger: 'onTokenGeneration',
     resetClaims: true,
-    kindeAPIs: {
-        fetch: {}
+    bindings:{
+        "global": {
+            "console": {},
+        },
+        "native": {
+            "kinde.fetch": {},
+            "kinde.idToken": {},
+            "kinde.accessToken": {}
+        }
     }
 };
+
+// bindings: ["console", "kinde.fetch", "kinde.idToken", "kinde.accessToken"],
+// settings: {
+//     "console": {},
+//     "kinde.idToken": {
+//         "resetClaims": true
+//     },
+// }
 
 export default async function handle (event: any) {
         kinde.idToken.setCustomClaim('random', 'test');
@@ -16,5 +31,4 @@ export default async function handle (event: any) {
         await kinde.fetch("http://google.com");
         console.error('error log');
         return 'testing return';
-
 }

--- a/testData/kindeSrc/environment/workflows/evTest2/authWorkflow.ts
+++ b/testData/kindeSrc/environment/workflows/evTest2/authWorkflow.ts
@@ -3,7 +3,17 @@ import {hello} from "./hello"
 export const workflowSettings = {
     id: 'tokenGen2',
     trigger: 'onTokenGeneration2',
-    resetClaims: true
+    resetClaims: true,
+    bindings:{
+        "global": {
+            "console": {},
+        },
+        "native": {
+            "kinde.fetch": {},
+            "kinde.idToken": {},
+            "kinde.accessToken": {}
+        }
+    }
 };
 
 export default {

--- a/testData/kindeSrc/environment/workflows/evTest2/authWorkflow.ts
+++ b/testData/kindeSrc/environment/workflows/evTest2/authWorkflow.ts
@@ -1,20 +1,20 @@
 import {hello} from "./hello"
 
 export const workflowSettings = {
-    id: 'tokenGen2',
-    trigger: 'onTokenGeneration2',
-    resetClaims: true,
+    id: 'tokenGen',
+    trigger: 'onTokenGeneration',
     bindings:{
-        "global": {
-            "console": {},
+        "console": {},
+        "kinde.fetch": {},
+        "kinde.idToken": {
+            resetClaims: true
         },
-        "native": {
-            "kinde.fetch": {},
-            "kinde.idToken": {},
-            "kinde.accessToken": {}
+        "kinde.accessToken": {
+            resetClaims: true
         }
     }
 };
+
 
 export default {
     async handle(event: any) {

--- a/workflowBundler/workflowBundler.go
+++ b/workflowBundler/workflowBundler.go
@@ -12,9 +12,9 @@ import (
 
 type (
 	WorkflowSettings struct {
-		ID       string                    `json:"id"`
-		Other    map[string]interface{}    `json:"other"`
-		Bindings runtimesRegistry.Bindings `json:"bindings"`
+		ID       string                                      `json:"id"`
+		Other    map[string]interface{}                      `json:"other"`
+		Bindings map[string]runtimesRegistry.BindingSettings `json:"bindings"`
 	}
 	BundledContent struct {
 		Source     []byte           `json:"source"`

--- a/workflowBundler/workflowBundler.go
+++ b/workflowBundler/workflowBundler.go
@@ -22,8 +22,8 @@ type (
 	}
 
 	BundlerResult struct {
-		Bundle BundledContent `json:"bundle"`
-		Errors []error        `json:"errors"`
+		Content BundledContent `json:"bundle"`
+		Errors  []error        `json:"errors"`
 	}
 
 	BundlerOptions struct {
@@ -81,14 +81,14 @@ func (b *builder) Bundle() BundlerResult {
 		}
 
 		file := tr.OutputFiles[0]
-		result.Bundle = BundledContent{
+		result.Content = BundledContent{
 			Source:     file.Contents,
 			BundleHash: file.Hash,
 			Settings:   result.discoverSettings(file.Contents),
 		}
 	}
 
-	if result.Bundle.Settings.ID == "" {
+	if result.Content.Settings.ID == "" {
 		result.addError(errors.New("workflow id not found, please export workflowSettings.id"))
 	}
 
@@ -96,7 +96,7 @@ func (b *builder) Bundle() BundlerResult {
 }
 
 func (br *BundlerResult) HasOutput() bool {
-	return len(br.Bundle.Source) > 0
+	return len(br.Content.Source) > 0
 }
 
 func (br *BundlerResult) addError(err error) {
@@ -107,7 +107,7 @@ func (br *BundlerResult) discoverSettings(source []byte) WorkflowSettings {
 	goja, _ := runtimesRegistry.ResolveRuntime("goja")
 	introspectResult, _ := goja.Introspect(context.Background(),
 		runtimesRegistry.WorkflowDescriptor{
-			ProcessedSource: runtimesRegistry.CodeDescriptor{
+			ProcessedSource: runtimesRegistry.SourceDescriptor{
 				Source:     source,
 				SourceType: runtimesRegistry.Source_ContentType_Text,
 			},

--- a/workflowBundler/workflowBundler.go
+++ b/workflowBundler/workflowBundler.go
@@ -112,7 +112,9 @@ func (br *BundlerResult) discoverSettings(source []byte) WorkflowSettings {
 				SourceType: runtimesRegistry.Source_ContentType_Text,
 			},
 			RequestedBindings: runtimesRegistry.Bindings{
-				Global: map[string]runtimesRegistry.ModuleBinding{},
+				Global: map[string]runtimesRegistry.ModuleBinding{
+					"module": {},
+				},
 			},
 			Limits: runtimesRegistry.RuntimeLimits{
 				MaxExecutionDuration: 30 * time.Second,

--- a/workflowBundler/workflowBundler.go
+++ b/workflowBundler/workflowBundler.go
@@ -111,13 +111,8 @@ func (br *BundlerResult) discoverSettings(source []byte) WorkflowSettings {
 				Source:     source,
 				SourceType: runtimesRegistry.Source_ContentType_Text,
 			},
-			Bindings: runtimesRegistry.Bindings{
-				GlobalModules: map[string]runtimesRegistry.ModuleBinding{
-					"console": {},
-					"url":     {},
-					"module":  {},
-					"kinde":   {},
-				},
+			RequestedBindings: runtimesRegistry.Bindings{
+				Global: map[string]runtimesRegistry.ModuleBinding{},
 			},
 			Limits: runtimesRegistry.RuntimeLimits{
 				MaxExecutionDuration: 30 * time.Second,

--- a/workflowBundler/workflowBundler_test.go
+++ b/workflowBundler/workflowBundler_test.go
@@ -19,8 +19,8 @@ func Test_WorkflowBundler(t *testing.T) {
 
 	assert := assert.New(t)
 	assert.Nil(bundlerResult.Errors, "errors were not expected")
-	assert.NotEmpty(bundlerResult.Bundle.Source)
-	assert.Equal("tokenGen", bundlerResult.Bundle.Settings.ID)
-	assert.Equal("onTokenGeneration", bundlerResult.Bundle.Settings.Other["trigger"])
-	assert.NotEmpty(bundlerResult.Bundle.BundleHash)
+	assert.NotEmpty(bundlerResult.Content.Source)
+	assert.Equal("tokenGen", bundlerResult.Content.Settings.ID)
+	assert.Equal("onTokenGeneration", bundlerResult.Content.Settings.Other["trigger"])
+	assert.NotEmpty(bundlerResult.Content.BundleHash)
 }


### PR DESCRIPTION
We didn't have ability to setup custom go APIs before, or bind to them.

Since separate executions could have separate bindings, introduced binding configuration 

e.g.

```
export const workflowSettings = {
    id: 'tokenGen',
    trigger: 'onTokenGeneration',
    bindings:{
        "console": {},
        "kinde.fetch": {},
        "kinde.idToken": {
            resetClaims: true
        },
        "kinde.accessToken": {
            resetClaims: true
        }
    }
};
```

In this example `kinde.fetch` and other kinde APIs are bound to the native functions.