### PR TITLE
Ev/console_and_logging

### DIFF
--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -25,14 +25,14 @@ type (
 
 	LogLevel int
 
-	RuntimeLogger interface {
+	Logger interface {
 		Log(level LogLevel, params ...interface{})
 	}
 
 	StartOptions struct {
 		EntryPoint string
 		Arguments  []interface{}
-		Loggger    RuntimeLogger
+		Loggger    Logger
 	}
 
 	SourceDescriptor struct {
@@ -84,6 +84,7 @@ type (
 
 	IntrospectionOptions struct {
 		Exports []string
+		Logger  Logger
 	}
 
 	Runner interface {

--- a/registry/runtimeRegistry.go
+++ b/registry/runtimeRegistry.go
@@ -12,14 +12,27 @@ import (
 const (
 	Source_ContentType_Text   SourceContentType = iota
 	Source_ContentType_Binary                   = iota
+
+	LogLevelInfo LogLevel = iota
+	LogLevelDebug
+	LogLevelWarning
+	LogLevelError
+	LogLevelSilent
 )
 
 type (
 	SourceContentType int
 
+	LogLevel int
+
+	RuntimeLogger interface {
+		Log(level LogLevel, params ...interface{})
+	}
+
 	StartOptions struct {
 		EntryPoint string
 		Arguments  []interface{}
+		Loggger    RuntimeLogger
 	}
 
 	SourceDescriptor struct {
@@ -48,14 +61,13 @@ type (
 	}
 
 	ExecutionMetadata struct {
-		StartedAt         time.Time     `json:"started_at"`
-		ExecutionDuration time.Duration `json:"execution_duration"`
+		StartedAt          time.Time     `json:"started_at"`
+		ExecutionDuration  time.Duration `json:"execution_duration"`
+		HasRunToCompletion bool          `json:"has_run_to_completion"`
 	}
 	ExecutionResult interface {
 		ExecutionMetadata() ExecutionMetadata
 		GetExitResult() interface{}
-		GetConsoleLog() []interface{}
-		GetConsoleError() []interface{}
 		GetContext() RuntimeContext
 	}
 


### PR DESCRIPTION
Instead og aggregating console logs in memory, streaming them via the callback.

Unified all console logs into a single stream.