### PR TITLE
Passing settings context to be used in plugins

### DIFF
--- a/projectBundler/projectBundler_test.go
+++ b/projectBundler/projectBundler_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func Test_ProjectBunler(t *testing.T) {
+
+	assert := assert.New(t)
+
 	somePathInsideProject, _ := filepath.Abs("../testData/kindeSrc/environment") //starting in a middle of nowhere, so we need to go up to the root of the project
 
 	type workflowSettings struct {
@@ -23,17 +26,19 @@ func Test_ProjectBunler(t *testing.T) {
 	onPageDiscoveredCalled := 0
 	projectBundler := NewProjectBundler(DiscoveryOptions[workflowSettings, pageSettings]{
 		StartFolder: somePathInsideProject,
-		OnWorkflowDiscovered: func(bundle *bundler.BundlerResult[workflowSettings]) {
+		OnWorkflowDiscovered: func(ctx context.Context, bundle *bundler.BundlerResult[workflowSettings]) {
 			onWorkflowDiscoveredCalled++
+			settings := ctx.Value(ProjectSettingsContextKey)
+			assert.NotNil(settings)
 		},
-		OnPageDiscovered: func(bundle *bundler.BundlerResult[pageSettings]) {
+		OnPageDiscovered: func(ctx context.Context, bundle *bundler.BundlerResult[pageSettings]) {
 			onPageDiscoveredCalled++
+			settings := ctx.Value(ProjectSettingsContextKey)
+			assert.NotNil(settings)
 		},
 	})
 
 	kindeProject, discoveryError := projectBundler.Discover(context.Background())
-
-	assert := assert.New(t)
 
 	if !assert.Nil(discoveryError) {
 		t.FailNow()

--- a/workflowBundler/workflowBundler.go
+++ b/workflowBundler/workflowBundler.go
@@ -37,7 +37,7 @@ type (
 		WorkingFolder       string
 		EntryPoints         []string
 		IntrospectionExport string
-		OnDiscovered        func(bundle *BundlerResult[TSettings])
+		OnDiscovered        func(ctx context.Context, bundle *BundlerResult[TSettings])
 	}
 
 	WorkflowBundler[TSettings any] interface {
@@ -122,7 +122,7 @@ func (b *builder[TSettings]) Bundle(ctx context.Context) BundlerResult[TSettings
 	}
 
 	if b.bundleOptions.OnDiscovered != nil {
-		b.bundleOptions.OnDiscovered(&result)
+		b.bundleOptions.OnDiscovered(ctx, &result)
 	}
 
 	return result

--- a/workflowBundler/workflowBundler_test.go
+++ b/workflowBundler/workflowBundler_test.go
@@ -20,11 +20,11 @@ func Test_WorkflowBundler(t *testing.T) {
 
 	pluginSetupWasCalled := false
 
-	workflowBuilder := NewWorkflowBundler[workflowSettings](BundlerOptions[workflowSettings]{
+	workflowBuilder := NewWorkflowBundler(BundlerOptions[workflowSettings]{
 		WorkingFolder:       workflowPath,
 		EntryPoints:         []string{"tokensWorkflow.ts"},
 		IntrospectionExport: "workflowSettings",
-		OnDiscovered: func(bundle *BundlerResult[workflowSettings]) {
+		OnDiscovered: func(_ context.Context, bundle *BundlerResult[workflowSettings]) {
 			bundle.Errors = append(bundle.Errors, "ID is required")
 		},
 	})


### PR DESCRIPTION
# Passing settings context to be used in plugins

# Checklist

- [*] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [*] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
