### PR TITLE
Add timeout test for GojaRunnerV1

### DIFF
--- a/runtime_test.go
+++ b/runtime_test.go
@@ -134,6 +134,48 @@ func Test_GojaPrecompiledRuntime(t *testing.T) {
 	}
 }
 
+func Test_GojaPrecompiledRuntimeTimeout(t *testing.T) {
+	runner := getGojaRunner()
+
+	for i := 0; i < 2; i++ {
+
+		workflowRuncontext := context.WithValue(context.Background(), testContextValue, "test"+fmt.Sprint(i))
+
+		result, err := runner.Execute(workflowRuncontext, registry.WorkflowDescriptor{
+			Limits: registry.RuntimeLimits{
+				MaxExecutionDuration: 2 * time.Second,
+			},
+			ProcessedSource: registry.SourceDescriptor{
+				Source: []byte(`
+
+				var r=Object.defineProperty;var a=Object.getOwnPropertyDescriptor;var s=Object.getOwnPropertyNames;var g=Object.prototype.hasOwnProperty;var f=(t,e)=>{for(var n in e)r(t,n,{get:e[n],enumerable:!0})},i=(t,e,n,l)=>{if(e&&typeof e=="object"||typeof e=="function")for(let o of s(e))!g.call(t,o)&&o!==n&&r(t,o,{get:()=>e[o],enumerable:!(l=a(e,o))||l.enumerable});return t};var u=t=>i(r({},"__esModule",{value:!0}),t);var h={};
+				f(h,{default:()=>c,workflowSettings:()=>w});module.exports=u(h);const w={resetClaims:!0};
+				var c={async handle(t){
+				while (true) {
+				}
+					return console.log("logging from workflow",{balh:"blah"}), console.error("error"), kinde.idToken.setCustomClaim('aaa', 'bbb'), kinde.accessToken.setCustomClaim('ccc', 'ddd'), kinde.fetch("hello.com")}
+				};//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsibWFpbiJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiXG5cbiAgICAgICAgICAgICAgICAgICAgZXhwb3J0IGNvbnN0IHdvcmtmbG93U2V0dGluZ3MgPSB7XG4gICAgICAgICAgICAgICAgICAgICAgICByZXNldENsYWltczogdHJ1ZVxuICAgICAgICAgICAgICAgICAgICB9O1xuXG5cdFx0XHRcdFx0ZXhwb3J0IGRlZmF1bHQge1xuICAgICAgICAgICAgICAgICAgICAgICAgYXN5bmMgaGFuZGxlKGV2ZW50OiBhbnkpIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb25zb2xlLmxvZygnbG9nZ2luZyBmcm9tIHdvcmtmbG93Jywge1wiYmFsaFwiOiBcImJsYWhcIn0pO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJldHVybiAndGVzdGluZyByZXR1cm4nO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICAgICAgIl0sCiAgIm1hcHBpbmdzIjogIjRaQUFBLElBQUFBLEVBQUEsR0FBQUMsRUFBQUQsRUFBQSxhQUFBRSxFQUFBLHFCQUFBQyxJQUFBLGVBQUFDLEVBQUFKLEdBRTJCLE1BQU1HLEVBQW1CLENBQzVCLFlBQWEsRUFDakIsRUFFZixJQUFPRCxFQUFRLENBQ0ksTUFBTSxPQUFPRyxFQUFZLENBQ3JCLGVBQVEsSUFBSSx3QkFBeUIsQ0FBQyxLQUFRLE1BQU0sQ0FBQyxFQUM5QyxnQkFDWCxDQUVKIiwKICAibmFtZXMiOiBbIm1haW5fZXhwb3J0cyIsICJfX2V4cG9ydCIsICJtYWluX2RlZmF1bHQiLCAid29ya2Zsb3dTZXR0aW5ncyIsICJfX3RvQ29tbW9uSlMiLCAiZXZlbnQiXQp9Cg=="}
+			`),
+				SourceType: registry.Source_ContentType_Text,
+			},
+			RequestedBindings: map[string]registry.BindingSettings{
+				"console":           {},
+				"url":               {},
+				"kinde.fetch":       {},
+				"kinde.idToken":     {},
+				"kinde.accessToken": {},
+			},
+		}, registry.StartOptions{
+			EntryPoint: "handle",
+		})
+
+		assert := assert.New(t)
+		assert.NotNil(err)
+		assert.Greater(result.ExecutionMetadata().ExecutionDuration.Nanoseconds(), int64(1))
+		assert.False(result.ExecutionMetadata().StartedAt.IsZero())
+	}
+}
+
 func Test_ProjectBunlerE2E(t *testing.T) {
 	somePathInsideProject, _ := filepath.Abs("./testData/kindeSrc/environment/workflows") //starting in a middle of nowhere, so we need to go up to the root of the project
 


### PR DESCRIPTION
Introduce a test to validate the timeout functionality in the GojaRunnerV1, ensuring that execution duration exceeds specified limits. Adjust error handling in the Execute method to return execution results instead of nil.