### PR TITLE
Added async execution to vm to better handle panics

### DIFF
--- a/gojaRuntime/runtime_test.go
+++ b/gojaRuntime/runtime_test.go
@@ -1,0 +1,29 @@
+package goja_runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVmPanicHandling(t *testing.T) {
+
+	result := ""
+	err := asyncRun(context.Background(), func(ctx context.Context) error {
+		vm := goja.New()
+		go func() {
+			time.Sleep(1 * time.Second)
+			vm.Interrupt("test interrupt") // kill script after 1 second
+		}()
+		_, err := vm.RunString("while (true) {}") //infinite loop
+		defer func() {
+			result = "test after"
+		}()
+		return err
+	})
+	assert.Error(t, err)
+	assert.Equal(t, "test after", result)
+}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -93,7 +93,7 @@ func Test_GojaLogVmInits(t *testing.T) {
 func Test_GojaPrecompiledRuntime(t *testing.T) {
 	runner := getGojaRunner()
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 
 		workflowRuncontext := context.WithValue(context.Background(), testContextValue, "test"+fmt.Sprint(i))
 


### PR DESCRIPTION
# Explain your changes

Vm interruptions modelled as a panic, which would panic the whole goroutine, e.g. ehen used as part of the request, the whole request is gettin gcancelled.

This PR adds panic handling and error reporting not to cause excessive terminations.