### PR TITLE
Change interrupt message for context cancellation

### DIFF
--- a/gojaRuntime/gojaRuntime.go
+++ b/gojaRuntime/gojaRuntime.go
@@ -471,7 +471,7 @@ func (*GojaRunnerV1) maxExecutionTimeout(ctx context.Context, vm *goja.Runtime, 
 		timer := time.NewTimer(maxExecutionDuration)
 		select {
 		case <-ctx.Done():
-			vm.Interrupt("execution time exceeded")
+			vm.Interrupt("execution cancelled by user")
 			if !timer.Stop() {
 				<-timer.C
 			}


### PR DESCRIPTION
Update the interrupt message to indicate that execution was cancelled by the user instead of exceeding the execution time.